### PR TITLE
Add missing `\fi`.

### DIFF
--- a/fancyhandout/fancyhandout.cls
+++ b/fancyhandout/fancyhandout.cls
@@ -221,7 +221,7 @@
 					\ifx\inserttitle\@empty\else {\LARGE\bfseries\inserttitle} \\[\smallskipamount] \fi
 					\ifx\insertsubtitle\@empty\else {\large\insertsubtitle} \\ \fi
 					\vspace{\medskipamount}\small
-					\ifx\insertauthor\@empty\else \insertauthor \ifx\insertinstitute\@empty \\[\medskipamount] \else \\ \fi
+					\ifx\insertauthor\@empty\else \insertauthor \ifx\insertinstitute\@empty \\[\medskipamount] \else \\ \fi\fi
 					\ifx\insertinstitute\@empty\else \insertinstitute \\[\medskipamount] \fi
 					\insertdate
 				\vspace{\medskipamount}}}}%


### PR DESCRIPTION
When no `\author` is specified, the following error occurs when calling `\maketitle`:

```
Running `LaTeX' on `fancyhdt' with ``pdflatex  -file-line-error   -interaction=nonstopmode "\input" fancyhdt.tex''
This is pdfTeX, Version 3.14159265-2.6-1.40.18 (TeX Live 2017) (preloaded format=pdflatex)
 restricted \write18 enabled.
entering extended mode
LaTeX2e <2017-04-15>
Babel <3.16> and hyphenation patterns for 84 language(s) loaded.
(./fancyhdt.tex
(/usr/local/texlive/2016/texmf-dist/tex/latex/fancyhandout/fancyhandout.cls
Document Class: fancyhandout 2018/01/20 fancyhandout: A LaTeX class for producing nice-looking handouts
(/usr/local/texlive/2016/texmf-dist/tex/latex/etoolbox/etoolbox.sty)
(/usr/local/texlive/2016/texmf-dist/tex/latex/base/article.cls
Document Class: article 2014/09/29 v1.4h Standard LaTeX document class
(/usr/local/texlive/2016/texmf-dist/tex/latex/base/size10.clo))
(/usr/local/texlive/2016/texmf-dist/tex/latex/geometry/geometry.sty
(/usr/local/texlive/2016/texmf-dist/tex/latex/graphics/keyval.sty)
(/usr/local/texlive/2016/texmf-dist/tex/generic/oberdiek/ifpdf.sty)
(/usr/local/texlive/2016/texmf-dist/tex/generic/oberdiek/ifvtex.sty)
(/usr/local/texlive/2016/texmf-dist/tex/generic/ifxetex/ifxetex.sty))
(/usr/local/texlive/2016/texmf-dist/tex/latex/enumitem/enumitem.sty)
(/usr/local/texlive/2016/texmf-dist/tex/latex/fancyhdr/fancyhdr.sty)
(/usr/local/texlive/2016/texmf-dist/tex/latex/xcolor/xcolor.sty
(/usr/local/texlive/2016/texmf-dist/tex/latex/graphics-cfg/color.cfg)
(/usr/local/texlive/2016/texmf-dist/tex/latex/graphics-def/pdftex.def)))
(/usr/local/texlive/2016/texmf-dist/tex/latex/base/inputenc.sty
(/usr/local/texlive/2016/texmf-dist/tex/latex/base/utf8.def
(/usr/local/texlive/2016/texmf-dist/tex/latex/base/t1enc.dfu)
(/usr/local/texlive/2016/texmf-dist/tex/latex/base/ot1enc.dfu)
(/usr/local/texlive/2016/texmf-dist/tex/latex/base/omsenc.dfu)))
(/usr/local/texlive/2016/texmf-dist/tex/latex/base/fontenc.sty
(/usr/local/texlive/2016/texmf-dist/tex/latex/base/t1enc.def))
(/usr/local/texlive/2016/texmf-dist/tex/latex/csquotes/csquotes.sty
(/usr/local/texlive/2016/texmf-dist/tex/latex/csquotes/csquotes.def)
(/usr/local/texlive/2016/texmf-dist/tex/latex/csquotes/csquotes.cfg))
(./fancyhdt.aux) (/usr/local/texlive/2016/texmf-dist/tex/latex/base/t1cmss.fd)
*geometry* driver: auto-detecting
*geometry* detected driver: pdftex
(/usr/local/texlive/2016/texmf-dist/tex/context/base/mkii/supp-pdf.mkii
[Loading MPS to PDF converter (version 2006.09.02).]
) (/usr/local/texlive/2016/texmf-dist/tex/latex/base/t1cmtt.fd))
! Incomplete \ifx; all text was ignored after line 14.
<inserted text> 
                \fi 
<*> \input fancyhdt.tex
                       
! Emergency stop.
<*> \input fancyhdt.tex
                       
!  ==> Fatal error occurred, no output PDF file produced!
Transcript written on fancyhdt.log.

TeX Output exited abnormally with code 1 at Mon Jan 22 09:40:04

```

This is caused by a missing `\fi` in the `\maketitle` command definition.  This PR fixes that issue.